### PR TITLE
MongoDB g flag in regex no longer supported

### DIFF
--- a/modules/checker.js
+++ b/modules/checker.js
@@ -19,7 +19,7 @@ module.exports.valid_url = function valid_url(loc, type){
     });
 
     var purl = parse(loc, true);
-    account = Account.findOne({ domain: {$regex: purl.hostname , $options: 'ig'} }).exec(function (err, account) {
+    account = Account.findOne({ domain: {$regex: purl.hostname , $options: 'i'} }).exec(function (err, account) {
       if(account){
         resolve(account.cif);
       }else{

--- a/worker.js
+++ b/worker.js
@@ -27,7 +27,7 @@ new CronJob('*/5 * * * * *', function() {
           console.log('Notifying url: ' + url.location);
           var purl = parse(url.location, true);
           try{
-            account = Account.findOne({ domain: {$regex: purl.hostname , $options: 'ig'} }).exec(function (err, account) {
+            account = Account.findOne({ domain: {$regex: purl.hostname , $options: 'i'} }).exec(function (err, account) {
               if(account){
                 var initializeIndexer = indexer.notify(url.location, url.type, account.cif);
                 initializeIndexer.then(function(urlDetails) {


### PR DESCRIPTION
I removed the g flag from mongoose regex as it was no longer supported by MongoDB.

https://www.mongodb.com/docs/upcoming/reference/operator/query/regex/#syntax
https://www.mongodb.com/community/forums/t/regex-flag-g-not-supported-in-aggregation-on-serverless-cluster/162363/3

This fixed this issue for me https://github.com/m3m3nto/giaa/issues/1 